### PR TITLE
feat(Route): allow for * and /path/to/* wildcard

### DIFF
--- a/src/Components.tsx
+++ b/src/Components.tsx
@@ -4,6 +4,16 @@ import useRouter from "./useRouter";
 export const Route = ({ children, path }: { children: any; path: string }) => {
   const { route } = useRouter();
   if (route == path) return <>{children}</>;
+  const routePathHasWildcard = path.indexOf('*') > -1;
+  const routePathIsWildcard = path == '*';
+  const userRouteIsRoot = route == '/';
+  if(routePathHasWildcard){
+      if(userRouteIsRoot) return null;
+      if(routePathIsWildcard) return <>{children}</>;
+      // If of the form /path/to/*, need to check for /path/to
+      const pathWithoutWildcard = path.replace(/\*$/, '');
+      if(route.startsWith(pathWithoutWildcard)) return <>{children}</>;
+  }
   return null;
 };
 


### PR DESCRIPTION
This is a small PR that add the ability for wildcards. 


See below for usage
```
import React, {Component} from "react";

export default class Router extends Component {
    render() {
        return (
            <blessed-box>
                <blessed-box
                    width="75%"
                    height="100%"
                    border={{ type: "line" }}
                    style={{ border: { fg: "blue" } }}>
                    <Route path="*">
                        <blessed-box>Base wildcard.</blessed-box>
                    </Route>
                    <Route path="/">
                        <blessed-box>This is the default ... route.</blessed-box>
                    </Route>
                    <Route path="/dashboard">
                        <DashboardPage />
                    </Route>
                    <Route path="/nodes/*">
                        <blessed-box>This is the node route.</blessed-box>
                    </Route>
                </blessed-box>
            </blessed-box>
        );
    }
}
```